### PR TITLE
Multiple changes - mainly added pet food cooldown and reorganized pom+plugin.yml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.9</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     </licenses>
 
     <build>
+        <finalName>${project.name}-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -30,6 +31,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <properties>
@@ -77,6 +84,7 @@
 
 
     <dependencies>
+
         <!-- Technical dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -84,7 +92,6 @@
             <version>RELEASE</version>
             <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -93,7 +100,6 @@
 
 
         <!-- Minecraft dependencies -->
-
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
@@ -104,12 +110,6 @@
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.21-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.mojang</groupId>
-            <artifactId>authlib</artifactId>
-            <version>1.5.21</version>
             <scope>provided</scope>
         </dependency>
 
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/fr/nocsy/mcpets/data/Pet.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Pet.java
@@ -159,6 +159,8 @@ public class Pet {
     @Setter
     private boolean enableSignalStickFromMenu;
 
+    private Map<String, Long> petFoodEatenTimestamps;
+
     //********** Entity features **********
 
     @Setter
@@ -215,6 +217,7 @@ public class Pet {
         this.instance = this;
         this.checkPermission = true;
         this.firstSpawn = true;
+        this.petFoodEatenTimestamps = new HashMap<>();
     }
 
     /**
@@ -506,6 +509,14 @@ public class Pet {
                 }
             }
         }
+    }
+
+    public long getFoodEatenTimestamp(String petFoodId) {
+        return petFoodEatenTimestamps.getOrDefault(petFoodId, 0L);
+    }
+
+    public void applyFoodCooldown(String petFoodId) {
+        petFoodEatenTimestamps.put(petFoodId, System.currentTimeMillis());
     }
 
     /**

--- a/src/main/java/fr/nocsy/mcpets/data/config/FormatArg.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/FormatArg.java
@@ -1,5 +1,7 @@
 package fr.nocsy.mcpets.data.config;
 
+import org.jetbrains.annotations.NotNull;
+
 public class FormatArg {
     private final String toReplace;
     private final String replaceWith;
@@ -7,6 +9,11 @@ public class FormatArg {
     public FormatArg(String toReplace, String replaceWith) {
         this.toReplace = toReplace;
         this.replaceWith = replaceWith;
+    }
+
+    public FormatArg(String toReplace, @NotNull Integer replaceWith) {
+        this.toReplace = toReplace;
+        this.replaceWith = Integer.toString(replaceWith);
     }
 
     /**

--- a/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
@@ -152,14 +152,14 @@ public class GlobalConfig extends AbstractConfig {
             getConfig().set("PercentHealthOnRespawn", 0.2);
         if (getConfig().get("ActivateBackMenuIcon") == null)
             getConfig().set("ActivateBackMenuIcon", true);
-        if(getConfig().get("AutoSaveDelay") == null)
+        if (getConfig().get("AutoSaveDelay") == null)
             getConfig().set("AutoSaveDelay", 3600);
 
-        if(getConfig().get("GlobalRespawnCooldown") == null)
+        if (getConfig().get("GlobalRespawnCooldown") == null)
             getConfig().set("GlobalRespawnCooldown", false);
-        if(getConfig().get("DefaultRespawnCooldown") == null)
+        if (getConfig().get("DefaultRespawnCooldown") == null)
             getConfig().set("DefaultRespawnCooldown", 0);
-        if(getConfig().get("AutoRespawn") == null)
+        if (getConfig().get("AutoRespawn") == null)
             getConfig().set("AutoRespawn", false);
         if (getConfig().get("Experience.BarSize") == null)
             getConfig().set("Experience.BarSize", 40);
@@ -181,7 +181,6 @@ public class GlobalConfig extends AbstractConfig {
         if (getConfig().get("Taming.ColorLeft") == null)
             getConfig().set("Taming.ColorLeft", "§f");
 
-
         if (getConfig().get("MySQL.Prefix") == null)
             getConfig().set("MySQL.Prefix", "");
         if (getConfig().get("MySQL.User") == null)
@@ -194,8 +193,10 @@ public class GlobalConfig extends AbstractConfig {
             getConfig().set("MySQL.Port", "2560");
         if (getConfig().get("MySQL.Database") == null)
             getConfig().set("MySQL.Database", "mcpets_db");
-        if(getConfig().get("BlackListedWorlds") == null)
+        if (getConfig().get("BlackListedWorlds") == null)
             getConfig().set("BlackListedWorlds", new ArrayList<String>());
+        if (getConfig().get("DisableMySQL") == null)
+            getConfig().set("DisableMySQL", false);
 
         save();
         reload();

--- a/src/main/java/fr/nocsy/mcpets/data/config/Language.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/Language.java
@@ -113,6 +113,7 @@ public enum Language {
 
     PET_ALREADY_TAMED("§cThis pet is already tamed."),
     PET_DOESNT_EAT("§cThis pet can not eat that food."),
+    PET_FOOD_ON_COOLDOWN("§cThe pet won't eat this food for another %timeleft% seconds"),
 
     PET_STATUS_ALIVE("§aAvailable"),
     PET_STATUS_REVOKED("§cUnavailable §7(%timeleft%s left)"),

--- a/src/main/java/fr/nocsy/mcpets/data/config/PetFoodConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/PetFoodConfig.java
@@ -51,6 +51,7 @@ public class PetFoodConfig extends AbstractConfig {
             double power = getConfig().getDouble(key + ".Power");
             PetMath operator = Optional.ofNullable(PetMath.get(getConfig().getString(key + ".Operator"))).orElse(PetMath.ADDITION);
             String signal = getConfig().getString(key + ".Signal");
+            long cooldown = getConfig().getLong(key + ".Cooldown", 0L) * 1000L;
             String evolution = getConfig().getString(key + ".Evolution");
             int experienceThreshold = getConfig().getInt(key + ".ExperienceThreshold");
             int delay = getConfig().getInt(key + ".DelayBeforeEvolution");
@@ -67,6 +68,7 @@ public class PetFoodConfig extends AbstractConfig {
                     foodType,
                     operator,
                     signal,
+                    cooldown,
                     evolution,
                     experienceThreshold,
                     delay,

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -141,7 +142,7 @@ public class PetInteractionMenuListener implements Listener {
 
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void chat(AsyncPlayerChatEvent e) {
         Player p = e.getPlayer();
 

--- a/src/main/java/fr/nocsy/mcpets/listeners/editor/EditorConversationListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/editor/EditorConversationListener.java
@@ -10,6 +10,7 @@ import fr.nocsy.mcpets.utils.PetMath;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -38,7 +39,7 @@ public class EditorConversationListener implements Listener {
         }.runTask(MCPets.getInstance());
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void listen_conversation(AsyncPlayerChatEvent e)
     {
         Player p = e.getPlayer();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: '${project.version}'
 description: MCModels affiliate plugin. Join the workshop ! https://discord.gg/p7QTm2gUyf
 load: STARTUP
 author: Nocsy
-website: ''
+website: 'https://mcpets.gitbook.io/mcpets'
 
 main: fr.nocsy.mcpets.MCPets
 api-version: 1.17

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,14 @@
-name: MCPets
-main: fr.nocsy.mcpets.MCPets
-version: 4.1.4
+name: '${project.name}'
+version: '${project.version}'
 description: MCModels affiliate plugin. Join the workshop ! https://discord.gg/p7QTm2gUyf
+load: STARTUP
+author: Nocsy
+website: ''
+
+main: fr.nocsy.mcpets.MCPets
+api-version: 1.17
+database: false
+prefix: '${project.name}'
 depend:
   - MythicMobs
   - ModelEngine
@@ -9,11 +16,19 @@ softdepend:
   - WorldGuard
   - LuckPerms
   - PlaceholderAPI
-author: Nocsy
-api-version: 1.17
+loadbefore: []
+
 commands:
   mcpets:
     description: Command to manage your pets
     Usage: /mcpets
     permission: mcpets.use
-    aliases: [ pets ]
+    aliases: [pets]
+
+permissions:
+  mcpets.use:
+    default: true
+  mcpets.admin:
+    default: op
+  mcpets.color:
+    default: op


### PR DESCRIPTION
Changes:
\+ Added pet food cooldown (per pet, per food item)
\* Fixed DisableMySQL not having default value set
\* Fixed compatibility/bug with some chat plugins - when renaming a pet in chat, the name was sent as a chat message despite event being cancelled
\* Organized pom - added finalName tag for local compiling, added resources tag to process placeholders in plugin.yml, removed unnecessary com.mojang.authlib dependency, updated placeholderapi dependency from non-existent 2.10.0 to 2.11.6
\* Reorganized plugin.yml - sorted lines by category, added some lines with default values as future template, changed name and version to use the pom values, added permissions