### PR TITLE
Itemsadder compatibility for pets food

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
             <id>bungeecord-repo</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
+        <repository>
+            <id>jitpack-repo</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
 
@@ -143,6 +147,12 @@
             <groupId>com.ticxo.modelengine</groupId>
             <artifactId>ModelEngine</artifactId>
             <version>R4.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.LoneDev6</groupId>
+            <artifactId>api-itemsadder</artifactId>
+            <version>3.6.1</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -146,7 +146,7 @@ public class MCPets extends JavaPlugin {
                 itemsAdder = customStackClass;
                 return true;
             } catch (ClassNotFoundException e) {
-                Bukkit.getLogger().warning("[MCPets] : ItemsAdder API not found.");
+                Bukkit.getLogger().info("[MCPets] : ItemsAdder API not found. Itemsadder custom items won't be available for pet foods.");
             }
         }
     

--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -142,7 +142,6 @@ public class MCPets extends JavaPlugin {
     
         if (Bukkit.getPluginManager().getPlugin("ItemsAdder") != null) {
             try {
-                // Verifica se a classe CustomStack está disponível
                 Class<?> customStackClass = Class.forName("dev.lone.itemsadder.api.CustomStack");
                 itemsAdder = customStackClass;
                 return true;

--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -20,6 +20,7 @@ import net.luckperms.api.LuckPerms;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import dev.lone.itemsadder.api.ItemsAdder;
 
 import java.util.logging.Logger;
 
@@ -30,6 +31,7 @@ public class MCPets extends JavaPlugin {
 
     private static MythicBukkit mythicMobs;
     private static LuckPerms luckPerms;
+    private static Object itemsAdder;
     private static boolean luckPermsNotFound = false;
 
     @Getter
@@ -73,6 +75,7 @@ public class MCPets extends JavaPlugin {
         checkWorldGuard();
         checkLuckPerms();
         checkPlaceholderApi();
+        checkItemsAdder();
 
         try {
             if (GlobalConfig.getInstance().isWorldguardsupport())
@@ -130,6 +133,25 @@ public class MCPets extends JavaPlugin {
                 Bukkit.getLogger().warning("[MCPets] : LuckPerms could not be found. Some features relating to giving permissions won't be available.");
             }
         }
+    }
+
+    private static boolean checkItemsAdder() {
+        if (itemsAdder != null) {
+            return true;
+        }
+    
+        if (Bukkit.getPluginManager().getPlugin("ItemsAdder") != null) {
+            try {
+                // Verifica se a classe CustomStack está disponível
+                Class<?> customStackClass = Class.forName("dev.lone.itemsadder.api.CustomStack");
+                itemsAdder = customStackClass;
+                return true;
+            } catch (ClassNotFoundException e) {
+                Bukkit.getLogger().warning("[MCPets] : ItemsAdder API not found.");
+            }
+        }
+    
+        return false;
     }
 
     /**
@@ -203,5 +225,15 @@ public class MCPets extends JavaPlugin {
         return luckPerms;
     }
 
+    /**
+     * Return ItemsAdder instance
+     * @return
+     */
+    public static Object getItemsAdder()
+    {
+        if(itemsAdder == null)
+            checkItemsAdder();
+        return itemsAdder;
+    }
 
 }

--- a/src/main/java/fr/nocsy/mcpets/data/livingpets/PetFood.java
+++ b/src/main/java/fr/nocsy/mcpets/data/livingpets/PetFood.java
@@ -364,16 +364,18 @@ public class PetFood {
      * Consume the pet food in the main hand of the player
      * @param p
      */
-    public void consume(Player p)
-    {
-        if(p == null)
-            return;
-
-        ItemStack it = itemStack.clone();
-        it.setAmount(p.getInventory().getItemInMainHand().getAmount()-1);
-        if(it.getAmount() == 0)
-            it = new ItemStack(Material.AIR);
-        p.getInventory().setItemInMainHand(it);
+    public void consume(Player p) {
+        if (p == null) return;
+    
+        ItemStack mainHandItem = p.getInventory().getItemInMainHand();
+        if (mainHandItem == null || mainHandItem.getType().isAir()) return;
+    
+        int currentAmount = mainHandItem.getAmount();
+        if (currentAmount <= 1) {
+            p.getInventory().setItemInMainHand(new ItemStack(Material.AIR));
+        } else {
+            mainHandItem.setAmount(currentAmount - 1);
+        }
     }
 
     /**

--- a/src/main/java/fr/nocsy/mcpets/data/livingpets/PetFood.java
+++ b/src/main/java/fr/nocsy/mcpets/data/livingpets/PetFood.java
@@ -17,7 +17,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
-import dev.lone.itemsadder.api.CustomStack;
 
 import java.util.*;
 
@@ -133,15 +132,25 @@ public class PetFood {
         // Setup the item stack
         if(itemStack == null)
         {
-            if (itemId.contains("itemsadder")) {
+            if (itemId.contains("itemsadder") && MCPets.getItemsAdder() != null) {
                 // Expected: itemsadder-namespace:item_name
                 String[] parts = itemId.split("-", 2);
-                
+            
                 if (parts.length == 2 && parts[0].equalsIgnoreCase("itemsadder")) {
-                    CustomStack customStack = CustomStack.getInstance(parts[1]);
-                    if (customStack != null) {
-                        itemStack = customStack.getItemStack();
-                        return itemStack;
+                    try {
+                        Class<?> customStackClass = (Class<?>) MCPets.getItemsAdder();
+                        Object customStack = customStackClass
+                            .getMethod("getInstance", String.class)
+                            .invoke(null, parts[1]);
+            
+                        if (customStack != null) {
+                            itemStack = (ItemStack) customStackClass
+                                .getMethod("getItemStack")
+                                .invoke(customStack);
+                            return itemStack;
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
                     }
                 }
             }
@@ -238,7 +247,6 @@ public class PetFood {
             String expectedItemName = itemStack.getItemMeta().getDisplayName();
 
             if (itemId.startsWith("itemsadder:")) {
-                // Comparar nomes de itens do ItemAdder
                 if (!itemName.equals(expectedItemName)) {
                     return false;
                 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: '${project.name}'
 version: '${project.version}'
 description: MCModels affiliate plugin. Join the workshop ! https://discord.gg/p7QTm2gUyf
-load: STARTUP
+load: POSTWORLD
 author: Nocsy
 website: 'https://mcpets.gitbook.io/mcpets'
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,6 +16,7 @@ softdepend:
   - WorldGuard
   - LuckPerms
   - PlaceholderAPI
+  - ItemsAdder
 loadbefore: []
 
 commands:


### PR DESCRIPTION
This PR adds a feature with ItemsAdder, I saw this problem in Discord:
![image](https://github.com/user-attachments/assets/c7341e9f-e266-4df5-b773-8a0cd4882fcf)

So, now players can use ItemsAdder items for `petsfood.yml`:
```yml
custom_food:
  ItemId: itemsadder-namespace:item_name
  Pets:
  - christmas_reindeer
  Type: EXP
  Operator: ADD
  Power: 1000.0
```


https://github.com/user-attachments/assets/81aa726f-a0a8-427f-aa6f-46578eea54bd


