### PR TITLE
Add ItemsAdder compat for Icon, PetFoods, Etc (feat. PR #40)

### DIFF
--- a/src/main/java/fr/nocsy/mcpets/MCPets.java
+++ b/src/main/java/fr/nocsy/mcpets/MCPets.java
@@ -28,7 +28,7 @@ public class MCPets extends JavaPlugin {
 
     private static MythicBukkit mythicMobs;
     private static LuckPerms luckPerms;
-    private static Object itemsAdder;
+    private static boolean itemsAdderFound = false;
     private static boolean luckPermsNotFound = false;
 
     @Getter
@@ -132,23 +132,14 @@ public class MCPets extends JavaPlugin {
         }
     }
 
-    private static boolean checkItemsAdder() {
-        if (itemsAdder != null) {
-            return true;
+    private static void checkItemsAdder() {
+        try {
+            Class.forName("dev.lone.itemsadder.api.CustomStack");
+            itemsAdderFound = true;
+        } catch (ClassNotFoundException e) {
+            itemsAdderFound = false;
+            Bukkit.getLogger().warning("[MCPets] : ItemsAdder could not be found. custom items features won't be available.");
         }
-    
-        if (Bukkit.getPluginManager().getPlugin("ItemsAdder") != null) {
-            try {
-                Class<?> customStackClass = Class.forName("dev.lone.itemsadder.api.CustomStack");
-                itemsAdder = customStackClass;
-                return true;
-            }
-            catch (ClassNotFoundException e) {
-                Bukkit.getLogger().info("[MCPets] : ItemsAdder API not found. Itemsadder custom items won't be available for pet foods.");
-            }
-        }
-    
-        return false;
     }
 
     /**
@@ -223,12 +214,9 @@ public class MCPets extends JavaPlugin {
     }
 
     /**
-     * Return ItemsAdder instance
+     * Check ItemsAdder is loaded or not
      */
-    public static Object getItemsAdder() {
-        if (itemsAdder == null)
-            checkItemsAdder();
-
-        return itemsAdder;
+    public static boolean isItemsAdderLoaded() {
+        return itemsAdderFound;
     }
 }

--- a/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/PetConfig.java
@@ -1,5 +1,6 @@
 package fr.nocsy.mcpets.data.config;
 
+import dev.lone.itemsadder.api.CustomStack;
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.PPermission;
 import fr.nocsy.mcpets.data.Items;
@@ -219,6 +220,7 @@ public class PetConfig extends AbstractConfig {
                 name = defaultName;
             }
             String mat = getConfig().getString(path + ".Material");
+            String itemsAdder = getConfig().getString(path + ".ItemsAdder", "");
             int data = getConfig().getInt(path + ".CustomModelData");
             String textureBase = getConfig().getString(path + ".TextureBase64");
             List<String> description = getConfig().getStringList(path + ".Description");
@@ -226,6 +228,23 @@ public class PetConfig extends AbstractConfig {
                     item, showStats, localName,
                     name, description, mat, data, textureBase
             );
+            // ItemsAdder compat
+            if (MCPets.isItemsAdderLoaded() && !itemsAdder.isEmpty()) {
+                CustomStack customStack = CustomStack.getInstance(itemsAdder);
+                if (customStack != null) {
+                    ItemStack iaItem = customStack.getItemStack();
+                    itemStack = pet.buildItem(
+                            iaItem,
+                            showStats,
+                            localName,
+                            name,
+                            description,
+                            iaItem.getType().toString(),
+                            iaItem.getItemMeta().getCustomModelData(),
+                            textureBase
+                    );
+                }
+            }
         }
         return itemStack;
     }


### PR DESCRIPTION
enhance https://github.com/Nocsy-Workshop/mcpets/pull/40

1. there's no reason to use reflection every call CustomStack.(just check at init whether ItemsAdder can be found)
2. i want use ItemsAdder custom items to Icon and other items
3. I kept the code clean again & enhanced ``getFromItem`` method.

let me know if i missed something :D

here is example to use:

# petfoods.yml
```
Test_Pet_Food:
  ItemId: customitem:your_id
  Type: EXP
  Power: 10
  Operator: ADD
```

# Pets/your_pet.yml
```
Id: Your_Super_Pet
MythicMob: Super_Pet
Icon:
  ItemsAdder: superpet:super_bat_man # this will available only icon(but the below's name and description flag is active!)
  Name: SuperMan
  Material: PAPER # if ItemsAdder flag is exist, this will be ignored.
  CustomModelData: 123456 # if ItemsAdder flag is exist, this will be ignored.
  Description:
  - I'm Bat man
Signals:
  Values:
  - PLAY
  Item:
    Name: Awesome Signal Stick
    ItemsAdder: superpet:super_stick
    Material: STICK # also this flag will ignored
    CustomModelData: 123457 # also this flag will ignored
    Description:
    - Abracadabra!
```
