### PR TITLE
Created fast mount option in config

### DIFF
--- a/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
+++ b/src/main/java/fr/nocsy/mcpets/data/config/GlobalConfig.java
@@ -100,6 +100,10 @@ public class GlobalConfig extends AbstractConfig {
     private String MySQL_DB;
     @Getter
     private List<String> blackListedWorlds;
+    @Getter
+    private boolean fastMount;
+    @Getter
+    private boolean disableFastMountWhileHoldingSignalStick;
 
     @Getter
     @Setter
@@ -196,6 +200,10 @@ public class GlobalConfig extends AbstractConfig {
             getConfig().set("BlackListedWorlds", new ArrayList<String>());
         if (getConfig().get("DisableMySQL") == null)
             getConfig().set("DisableMySQL", false);
+        if  (getConfig().get("FastMount") == null)
+            getConfig().set("FastMount", false);
+        if  (getConfig().get("DisableFastMountWhileHoldingSignalStick") == null)
+            getConfig().set("DisableFastMountWhileHoldingSignalStick", false);
 
         save();
         reload();
@@ -262,6 +270,9 @@ public class GlobalConfig extends AbstractConfig {
         MySQL_PORT = getConfig().getString("MySQL.Port");
         MySQL_DB = getConfig().getString("MySQL.Database");
         blackListedWorlds = getConfig().getStringList("BlackListedWorlds");
+
+        fastMount = getConfig().getBoolean("FastMount");
+        disableFastMountWhileHoldingSignalStick = getConfig().getBoolean("DisableFastMountWhileHoldingSignalStick");
     }
 
     public boolean hasBlackListedWorld(String worldName) {

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
@@ -398,4 +398,43 @@ public class PetListener implements Listener {
                 pet.despawn(PetDespawnReason.FLAG);
         }
     }
+
+
+    @EventHandler
+    public void fastMount(PlayerInteractEntityEvent e){
+        // Check if inventories should be opening instead of fast mounting
+        if (GlobalConfig.getInstance().isRightClickToOpen())
+            return;
+        Player p = e.getPlayer();
+        if (GlobalConfig.getInstance().isSneakMode() && p.isSneaking())
+            return;
+
+        // Do not mount if the player has a signal stick
+        if (GlobalConfig.getInstance().isDisableFastMountWhileHoldingSignalStick()) {
+            ItemStack it = p.getInventory().getItemInMainHand();
+            if (Items.isSignalStick(it))
+                return;
+        }
+        //If it's pet food in the main hand then do not mount
+        if (PetFood.getFromItem(p.getInventory().getItemInMainHand()) != null) {
+            return;
+        }
+
+        if (!GlobalConfig.getInstance().isFastMount())
+            return;
+
+        Entity ent = e.getRightClicked();
+        Pet pet = Pet.getFromEntity(ent);
+        if (pet != null && pet.getOwner() != null &&
+                pet.getOwner().equals(p.getUniqueId())) {
+            PetOwnerInteractEvent event = new PetOwnerInteractEvent(pet);
+            Utils.callEvent(event);
+            if (event.isCancelled()) return;
+
+            PetInteractionMenuListener.mount(p, pet);
+
+        }
+
+    }
+
 }


### PR DESCRIPTION
Added fast mount to pet mechanic. When a player right clicks a pet then it will to try to mount it. Fast mount won't activate if the pet inventory should be opened first and also added an option to disable while you're holding a Signal Stick. 

```yaml
# only works with right click
FastMount: true
DisableFastMountWhileHoldingSignalStick: false
```
