### PR TITLE
Refactor inventory creation to use PetInventoryHolder

### DIFF
--- a/src/main/java/fr/nocsy/mcpets/compat/PlaceholderAPICompat.java
+++ b/src/main/java/fr/nocsy/mcpets/compat/PlaceholderAPICompat.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 public class PlaceholderAPICompat extends PlaceholderExpansion {
 
     @Override
-    public String onPlaceholderRequest(Player player, String identifier){
+    public String onPlaceholderRequest(Player player, @NotNull String identifier){
         String defaultOutput = "";
         
         if (player == null)

--- a/src/main/java/fr/nocsy/mcpets/data/Category.java
+++ b/src/main/java/fr/nocsy/mcpets/data/Category.java
@@ -1,6 +1,7 @@
 package fr.nocsy.mcpets.data;
 
 import fr.nocsy.mcpets.data.config.GlobalConfig;
+import fr.nocsy.mcpets.data.inventories.PetInventoryHolder;
 import lombok.Getter;
 import lombok.Setter;
 import org.bukkit.Bukkit;
@@ -90,7 +91,7 @@ public class Category {
                 invSize++;
         }
 
-        Inventory inventory = Bukkit.createInventory(null,  invSize, displayName);
+        Inventory inventory = new PetInventoryHolder(invSize, displayName).getInventory();
 
         if (maxPages > 1)
             inventory.setItem(invSize-1, Items.page(this, page));

--- a/src/main/java/fr/nocsy/mcpets/data/PetSkin.java
+++ b/src/main/java/fr/nocsy/mcpets/data/PetSkin.java
@@ -3,6 +3,7 @@ package fr.nocsy.mcpets.data;
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.config.FormatArg;
 import fr.nocsy.mcpets.data.config.Language;
+import fr.nocsy.mcpets.data.inventories.PetInventoryHolder;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -105,7 +106,7 @@ public class PetSkin {
         while (invSize <= 0 || invSize%9 != 0)
             invSize++;
 
-        Inventory inventory = Bukkit.createInventory(null, invSize, Language.PET_SKINS_TITLE.getMessageFormatted(new FormatArg("%pet%", pet.getIcon().getItemMeta().getDisplayName())));
+        Inventory inventory = new PetInventoryHolder(invSize, Language.PET_SKINS_TITLE.getMessageFormatted(new FormatArg("%pet%", pet.getIcon().getItemMeta().getDisplayName()))).getInventory();
 
         for (PetSkin petSkin : skins) {
             inventory.addItem(petSkin.getIcon());

--- a/src/main/java/fr/nocsy/mcpets/data/editor/EditorState.java
+++ b/src/main/java/fr/nocsy/mcpets/data/editor/EditorState.java
@@ -7,10 +7,10 @@ import fr.nocsy.mcpets.data.config.CategoryConfig;
 import fr.nocsy.mcpets.data.config.ItemsListConfig;
 import fr.nocsy.mcpets.data.config.PetConfig;
 import fr.nocsy.mcpets.data.config.PetFoodConfig;
+import fr.nocsy.mcpets.data.inventories.PetInventoryHolder;
 import fr.nocsy.mcpets.data.livingpets.PetFood;
 import fr.nocsy.mcpets.data.livingpets.PetLevel;
 import lombok.Getter;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
@@ -73,7 +73,7 @@ public enum EditorState {
     private void buildInventory(Player p) {
 
         if (this.equals(EditorState.GLOBAL_EDITOR)) {
-            currentView = Bukkit.createInventory(null, InventoryType.HOPPER, this.getMenuTitle());
+            currentView = new PetInventoryHolder(InventoryType.HOPPER, this.getMenuTitle()).getInventory();
 
             EditorItems[] icons = {
                     EditorItems.CONFIG_EDITOR,
@@ -91,7 +91,7 @@ public enum EditorState {
 
 
         else if (this.equals(EditorState.CONFIG_EDITOR)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             HashMap<EditorItems, Integer> icons = new HashMap<>();
 
@@ -127,7 +127,7 @@ public enum EditorState {
 
 
         else if (this.equals(EditorState.PET_EDITOR)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             for(int i = 45; i < 53; i++) {
                 currentView.setItem(i, EditorItems.FILLER.getItem());
@@ -160,7 +160,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.PET_EDITOR_EDIT)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             Pet pet = PetConfig.loadConfigPet(EditorEditing.get(p).getPetId());
             String filePath = PetConfig.getFilePath(pet.getId());
@@ -196,7 +196,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.PET_EDITOR_LEVELS)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             for(int i = 45; i <= 53; i++) {
                 currentView.setItem(i, EditorItems.FILLER.getItem());
@@ -223,7 +223,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.PET_EDITOR_LEVEL_EDIT)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
 
             EditorEditing editorPet = EditorEditing.get(p);
@@ -266,7 +266,7 @@ public enum EditorState {
         }
         else if (this.equals(EditorState.PET_EDITOR_SKINS)) {
 
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             for(int i = 45; i <= 53; i++) {
                 currentView.setItem(i, EditorItems.FILLER.getItem());
@@ -292,7 +292,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.PET_EDITOR_SKIN_EDIT)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             EditorEditing editorPet = EditorEditing.get(p);
             Pet pet = PetConfig.loadConfigPet(editorPet.getPetId());
@@ -318,7 +318,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.CATEGORY_EDITOR)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             for (int i = 45; i <= 53; i++) {
                 currentView.setItem(i, EditorItems.FILLER.getItem());
@@ -343,7 +343,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.CATEGORY_EDITOR_EDIT)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             EditorEditing editorEditing = EditorEditing.get(p);
             Category category = CategoryConfig.loadConfigCategory(editorEditing.getMappedId());
@@ -373,7 +373,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.ITEM_EDITOR)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             for (int i = 45; i <= 53; i++) {
                 currentView.setItem(i, EditorItems.FILLER.getItem());
@@ -402,7 +402,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.ITEM_EDITOR_EDIT)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             EditorEditing editorEditing = EditorEditing.get(p);
             String itemId = editorEditing.getMappedId();
@@ -424,7 +424,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.PETFOOD_EDITOR)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             for (int i = 45; i <= 53; i++) {
                 currentView.setItem(i, EditorItems.FILLER.getItem());
@@ -454,7 +454,7 @@ public enum EditorState {
             }
         }
         else if (this.equals(EditorState.PETFOOD_EDITOR_EDIT)) {
-            currentView = Bukkit.createInventory(null, 54, this.getMenuTitle());
+            currentView = new PetInventoryHolder(54, this.getMenuTitle()).getInventory();
 
             EditorEditing editorEditing = EditorEditing.get(p);
             PetFood petFood = PetFoodConfig.loadConfigPetFood(editorEditing.getMappedId());

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/CategoriesMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/CategoriesMenu.java
@@ -19,7 +19,7 @@ public class CategoriesMenu {
         while(invSize == 0 || invSize%9 != 0)
             invSize++;
 
-        Inventory inventory = Bukkit.createInventory(null, invSize, title);
+        Inventory inventory = new PetInventoryHolder(invSize, title).getInventory();
 
         Category.getCategories()
                 .forEach(category -> {

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInteractionMenu.java
@@ -26,7 +26,7 @@ public class PetInteractionMenu {
             return;
         }
         pet.setOwner(owner);
-        inventory = Bukkit.createInventory(null, 9, title);
+        inventory = new PetInventoryHolder(9, title).getInventory();
 
         if (GlobalConfig.getInstance().isActivateBackMenuIcon())
             inventory.setItem(0, Items.PETMENU.getItem());

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventory.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventory.java
@@ -44,7 +44,7 @@ public class PetInventory {
 
         String title = Language.PET_INVENTORY_TITLE.getMessageFormatted(new FormatArg("%pet%", pet.getIcon().getItemMeta().getDisplayName()));
 
-        this.inventory = Bukkit.createInventory(null, pet.getInventorySize(), title);
+        this.inventory = new PetInventoryHolder(pet.getInventorySize(), title).getInventory();
         if (premadeInventory != null) {
             if (premadeInventory.getContents().length <= inventory.getContents().length)
                 inventory.setContents(premadeInventory.getContents());

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventoryHolder.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetInventoryHolder.java
@@ -1,0 +1,29 @@
+package fr.nocsy.mcpets.data.inventories;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.jetbrains.annotations.NotNull;
+
+public class PetInventoryHolder implements InventoryHolder {
+    private final Inventory inventory;
+
+    public PetInventoryHolder(int size) {
+        this.inventory = Bukkit.createInventory(this, size);
+    }
+
+    public PetInventoryHolder(int size, @NotNull String title) {
+        this.inventory = Bukkit.createInventory(this, size, title);
+    }
+
+    public PetInventoryHolder(InventoryType inventoryType, @NotNull String title) {
+        this.inventory = Bukkit.createInventory(this, inventoryType, title);
+    }
+
+    @NotNull
+    @Override
+    public Inventory getInventory() {
+        return this.inventory;
+    }
+}

--- a/src/main/java/fr/nocsy/mcpets/data/inventories/PetMenu.java
+++ b/src/main/java/fr/nocsy/mcpets/data/inventories/PetMenu.java
@@ -68,7 +68,7 @@ public class PetMenu {
         }
 
         // Let's fill tbe view with the selected pets
-        inventory = Bukkit.createInventory(null, invSize, title);
+        inventory = new PetInventoryHolder(invSize, title).getInventory();
         for (Pet pet : selectedPets) {
             inventory.addItem(pet.buildItem(pet.getIcon(), true, null, null, null, null, 0, null));
         }

--- a/src/main/java/fr/nocsy/mcpets/listeners/CategoriesMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/CategoriesMenuListener.java
@@ -2,6 +2,7 @@ package fr.nocsy.mcpets.listeners;
 
 import fr.nocsy.mcpets.data.config.Language;
 import fr.nocsy.mcpets.data.inventories.CategoriesMenu;
+import fr.nocsy.mcpets.data.inventories.PetInventory;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -12,7 +13,7 @@ public class CategoriesMenuListener implements Listener {
 
     @EventHandler
     public void invClick(InventoryClickEvent e) {
-        if (e.getView().getTitle().equalsIgnoreCase(Language.CATEGORY_MENU_TITLE.getMessage())) {
+        if (e.getInventory() instanceof PetInventory) {
             ItemStack icon = e.getCurrentItem();
             if (icon != null) {
                 CategoriesMenu.openSubCategory((Player) e.getWhoClicked(), icon);

--- a/src/main/java/fr/nocsy/mcpets/listeners/CategoryMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/CategoryMenuListener.java
@@ -4,6 +4,7 @@ import fr.nocsy.mcpets.data.Category;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.config.GlobalConfig;
 import fr.nocsy.mcpets.data.inventories.CategoriesMenu;
+import fr.nocsy.mcpets.data.inventories.PetInventory;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -22,7 +23,7 @@ public class CategoryMenuListener implements Listener {
         Player p = (Player) e.getWhoClicked();
         Category category = Category.getCategoryView(p);
 
-        if (category != null && e.getView().getTitle().equalsIgnoreCase(category.getDisplayName())) {
+        if (category != null && e.getInventory() instanceof PetInventory) {
             e.setCancelled(true);
 
             if (e.getClickedInventory() == null && GlobalConfig.getInstance().isEnableClickBackToMenu()) {

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetInteractionMenuListener.java
@@ -72,7 +72,7 @@ public class PetInteractionMenuListener implements Listener {
 
     @EventHandler
     public void click(InventoryClickEvent e) {
-        if (e.getView().getTitle().equalsIgnoreCase(PetInteractionMenu.getTitle())) {
+        if (e.getInventory() instanceof PetInventory) {
             e.setCancelled(true);
 
             Player p = (Player) e.getWhoClicked();

--- a/src/main/java/fr/nocsy/mcpets/listeners/PetMenuListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetMenuListener.java
@@ -2,6 +2,7 @@ package fr.nocsy.mcpets.listeners;
 
 import fr.nocsy.mcpets.data.Category;
 import fr.nocsy.mcpets.data.Pet;
+import fr.nocsy.mcpets.data.inventories.PetInventory;
 import fr.nocsy.mcpets.data.inventories.PetMenu;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -14,7 +15,7 @@ public class PetMenuListener implements Listener {
 
     @EventHandler
     public void click(InventoryClickEvent e) {
-        if (e.getView().getTitle().equals(PetMenu.getTitle()) && Category.getCategories().isEmpty()) {
+        if (e.getInventory() instanceof PetInventory && Category.getCategories().isEmpty()) {
             e.setCancelled(true);
             Player p = (Player) e.getWhoClicked();
             ItemStack it = e.getCurrentItem();

--- a/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/DropPetInventoryMechanic.java
+++ b/src/main/java/fr/nocsy/mcpets/mythicmobs/mechanics/DropPetInventoryMechanic.java
@@ -3,6 +3,7 @@ package fr.nocsy.mcpets.mythicmobs.mechanics;
 import fr.nocsy.mcpets.MCPets;
 import fr.nocsy.mcpets.data.Pet;
 import fr.nocsy.mcpets.data.inventories.PetInventory;
+import fr.nocsy.mcpets.data.inventories.PetInventoryHolder;
 import io.lumine.mythic.api.adapters.AbstractEntity;
 import io.lumine.mythic.api.config.MythicLineConfig;
 import io.lumine.mythic.api.skills.ITargetedEntitySkill;
@@ -39,7 +40,7 @@ public class DropPetInventoryMechanic implements ITargetedEntitySkill {
                     }
                 });
 
-                petInventory.setInventory(Bukkit.createInventory(null, inv.getSize()));
+                petInventory.setInventory(new PetInventoryHolder(inv.getSize()).getInventory());
             }
         }
         catch (Exception ex) {


### PR DESCRIPTION
Replaces direct Bukkit.createInventory calls with PetInventoryHolder for all inventory creation, improving consistency and enabling custom inventory handling. Updates listeners to check for PetInventory instances instead of relying on inventory titles.

Closes #31 