### PR TITLE
Add pet permission checks surrounding reconnectionPets logic

### DIFF
--- a/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
+++ b/src/main/java/fr/nocsy/mcpets/listeners/PetListener.java
@@ -125,7 +125,9 @@ public class PetListener implements Listener {
         Pet pet = Pet.getActivePets().get(p.getUniqueId());
         if (pet != null) {
             pet.despawn(PetDespawnReason.DISCONNECTION);
-            reconnectionPets.put(p.getUniqueId(), pet.getId());
+            if (p.hasPermission(pet.getPermission())) {
+                reconnectionPets.put(p.getUniqueId(), pet.getId());
+            }
         }
     }
 
@@ -145,6 +147,12 @@ public class PetListener implements Listener {
                 Pet pet = Pet.getFromId(reconnectionPets.get(p.getUniqueId()));
                 if (pet == null)
                     return;
+
+                if (!p.hasPermission(pet.getPermission())) {
+                    reconnectionPets.remove(p.getUniqueId());
+                    return;
+                }
+
                 pet = pet.copy();
                 pet.setCheckPermission(false);
                 pet.setOwner(p.getUniqueId());
@@ -192,10 +200,10 @@ public class PetListener implements Listener {
                     return;
                 }
             }
-            
+
             if (GlobalConfig.getInstance().isDismountOnDamagedExcludePlayers())
                 return;
-                
+
             Player p = (Player) e.getEntity();
             Pet pet = Pet.fromOwner(p.getUniqueId());
             if (pet != null && pet.hasMount(p)) {


### PR DESCRIPTION
This pull request updates the logic for handling pet reconnection and disconnection events to ensure that only players with the required permissions have their pets saved and restored. The changes add permission checks during both disconnect and reconnect events, improving security and consistency in pet ownership.

**Permission handling improvements:**

* Added a permission check in `disconnectPlayer` so that only players who have the required pet permission will have their pet saved for reconnection.
* Added a permission check in `reconnectionPlayer` to prevent restoring pets to players who no longer have the required permission, and to remove their pet from the reconnection list if the check fails.

**My Use Case**

* The use case which sparked this change came during adding a "preview" system for players prior to purchasing a pet
  * Spawned a pet for a player ignoring permissions and revoked it 10 seconds later
  * The issue was if the player logged off prior to the revoking, the pet would be restored when they logged back on 
 
**Additional Benefits**
* This also fixes a case where if the player loses permission to a pet (say through a rank subscription) while offline, their pet will no longer be respawned for them when reconnecting